### PR TITLE
Fix backwards shift times in UI

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -317,7 +317,7 @@ chrome.runtime.onMessage.addListener(function (message, sender, sendResponse) {
                     });
                     chrome.storage.local.set({ 'shifts': responseData }, function () {
                         // Encrypt and store the access token
-                        console.log('shifts is set to ' + responseData[0].stringify());
+                        console.log('shifts is set to ' + JSON.stringify(responseData[0]));
                     });
                     console.log("Resent Request Response:", responseData);
                 })
@@ -435,7 +435,7 @@ chrome.webRequest.onBeforeRequest.addListener(
                                 });
                                 chrome.storage.local.set({ 'shifts': responseData }, function () {
                                     // Encrypt and store the access token
-                                    console.log('shifts is set to ' + responseData[0].stringify());
+                                    console.log('shifts is set to ' + JSON.stringify(responseData[0]));
                                 });
                                 console.log("Resent Request Response:", responseData);
                             })

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -261,11 +261,11 @@ function App() {
                     <StackItem>
                       <CalendarIcon />
                       {"  "}
-                      {shift['milend']}
+                      {shift['milstart']}
                       {" "}
                       <MinusIcon />
                       {" "}
-                      {shift['milstart']}
+                      {shift['milend']}
                     </StackItem>
                   </Stack>
                 </CardBody>


### PR DESCRIPTION
## Backwards shift times in UI
I noticed that the shift times shown in the extension UI are (accidentally, I assume!) shown backwards: the shift end time, then the shift start time. This PR makes a small update to the main React component to show the shift times in the correct order.

Here's how it looks after the change:
![Screenshot 2024-12-28 130539](https://github.com/user-attachments/assets/45e31ed0-ea69-4ad0-aa11-72c4eb70682e)

## Console logs throwing exceptions
There are also a few console logs in the service worker that are attempting to call `stringify()` on objects, which isn't a thing, so exceptions are being thrown on those lines. I don't think this was causing any actual issues, but I replaced those with `JSON.stringify()`.