### PR TITLE
Fix hardcoded eastern time zone for calendar events

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -14,7 +14,8 @@
     "permissions": [
         "identity",
         "storage",
-        "webRequest"
+        "webRequest",
+        "scripting"
     ],
     "host_permissions": [
         "https://*.subitup.com/*"


### PR DESCRIPTION
Fixes https://github.com/chriskim2273/SubItUp-Google-Calendar-Integration/issues/1.

First of all - really appreciate the development of this extension. My wife recently started a job where her shifts are tracked on SubItUp, and I literally couldn't believe that they don't provide any calendar integration of their own. Fortunately, she found this extension, which is a huge step up.

There is one significant issue though - her shifts are shown in central time on SubItUp. The extension hardcodes the time zone of all events to eastern time, so Google Calendar misunderstands when the shifts are taking place, and everything shows up an hour too early on her calendar.

Once I started digging into it, I understood a little better why it was like this...because the way time zones are handled between SubItUp, browsers, and the Calendar API are all different and dealing with it is super annoying.

## Approach
The user starts on the SubItUp schedule page, which shows the user's configured time zone in the sidebar.

<img width="277" alt="Screenshot 2024-12-28 125522" src="https://github.com/user-attachments/assets/e75a30b9-c449-44b4-b9ef-810aaef4e70a" />

Then:
1. In the extension, the user selects their shifts and clicks "Add To Google Calendar". The time zone description is read from the page and that string is passed to the service worker along with the other shift info. Reading information from the page also means we need to add the `scripting` permission to the extension manifest, unfortunately.
2. The service worker parses the 3-letter time zone abbreviation out of the SubItUp time zone description - that would be `CST` in the case of the screenshot above - and maps it to an AINA time zone name using a (lovingly hand-crafted) dictionary.
3. The server worker sets that AINA time zone name on the event when creation request is sent to the Google Calendar API. It falls back to `America/New_York` if necessary.
4. Correct time zones on calendar events!

![Screenshot 2024-12-28 125418](https://github.com/user-attachments/assets/e7725e36-d007-445b-b296-d5865cf120ed)

## Alternatives
This approach is pretty unsatisfying in some ways. The extension has to read from the page now, and it will need updates if SubItUp changes the structure of the page or the way the formatting of the time zone description. SubItUp could even remove the time zone description from the side bar entirely. And the three-letter abbreviations SubItUp uses don't match any particular standard I could find, so I just picked plausible time zones to map what they had.

Here are some other options I considered. Some are better than others:
* The shift objects in the SubItUp API have a `GMT` key. In the account I have access to, the key always has a value of `"-5"`. At first this seemed super useful, but then I noticed that the value didn't change when I changed the time zone on the account, and anyway an offset isn't a substitute for a time zone (what if you're adding next week's shifts just before daylight savings time takes effect?). So I don't know what this key is supposed to be used for.
* Send the event times in UTC. I think this would work, but as far as I can tell, shift times are only provided by SubItUp in terms of the user's configured time zone, not UTC. So we don't know what the event time would be in UTC!
* [Ask the browser for the user's time zone](https://stackoverflow.com/a/37512371). This seems close to good enough, but events will have the wrong time if the user's browser is in a different time zone than the SubItUp account, like if you're importing shifts for your job in San Francisco while on vacation in Hawaii.
* SubItUp has a mobile app, so they probably also have an API endpoint that includes information about the user's configured time zone. That sounds nicer than scraping the time zone off the page. I'm sure it wouldn't be that hard to watch the app's API calls to find out, but tbh I don't know how to do this.